### PR TITLE
Refactor canvas tools to require explicit canvas state

### DIFF
--- a/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
+++ b/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
@@ -12,13 +12,13 @@ import Konva from 'konva';
 import Timeline from './Timeline.vue';
 import HierarchicalMetadataEditor from './HierarchicalMetadataEditor.vue';
 import VisualizationToggles from './VisualizationToggles.vue';
-import { clearFreehandSelection, createStrokeShape, deserializeFreehandState, getStrokePath, gridSize, serializeFreehandState, updateBakedStrokeData, updateFreehandDraggableStates, updateTimelineState, type FreehandStroke, handleTimeUpdate, maxInterStrokeDelay, setUpdateCursor, updateCursor, downloadFreehandDrawing, uploadFreehandDrawing, setRefreshAVs, getCurrentFreehandStateString, restoreFreehandState, initFreehandLayers } from './freehandTool';
+import { clearFreehandSelection as clearFreehandSelectionImpl, createStrokeShape as createStrokeShapeImpl, deserializeFreehandState, getStrokePath, gridSize, serializeFreehandState, updateBakedStrokeData, updateFreehandDraggableStates as updateFreehandDraggableStatesImpl, updateTimelineState as updateTimelineStateImpl, type FreehandStroke, handleTimeUpdate as handleTimeUpdateImpl, maxInterStrokeDelay, setUpdateCursor, updateCursor, downloadFreehandDrawing as downloadFreehandDrawingImpl, uploadFreehandDrawing as uploadFreehandDrawingImpl, setRefreshAVs, getCurrentFreehandStateString, restoreFreehandState, initFreehandLayers } from './freehandTool';
 import { freehandStrokes, getGlobalCanvasState } from './canvasState';
 import { getPointsBounds } from './canvasUtils';
 import { CommandStack } from './commandStack';
 import { setGlobalExecuteCommand, setGlobalPushCommand } from './commands';
 import { ensureHighlightLayer } from '@/metadata';
-import { clearPolygonSelection, updatePolygonControlPoints, deserializePolygonState, handlePolygonClick, handlePolygonMouseMove, handlePolygonEditMouseMove, finishPolygon, clearCurrentPolygon, serializePolygonState, getCurrentPolygonStateString, restorePolygonState, updateBakedPolygonData, initPolygonLayers, setupPolygonModeWatcher } from './polygonTool';
+import { clearPolygonSelection as clearPolygonSelectionImpl, updatePolygonControlPoints as updatePolygonControlPointsImpl, deserializePolygonState, handlePolygonClick as handlePolygonClickImpl, handlePolygonMouseMove as handlePolygonMouseMoveImpl, handlePolygonEditMouseMove as handlePolygonEditMouseMoveImpl, finishPolygon as finishPolygonImpl, clearCurrentPolygon as clearCurrentPolygonImpl, serializePolygonState, getCurrentPolygonStateString, restorePolygonState, updateBakedPolygonData, initPolygonLayers, setupPolygonModeWatcher as setupPolygonModeWatcherImpl } from './polygonTool';
 import { initAVLayer, refreshAnciliaryViz } from './ancillaryVisualizations';
 import { initializeTransformer } from './transformerManager';
 import {
@@ -55,6 +55,25 @@ const duplicateSelectionStateful = () => duplicateSelectionImpl(canvasState)
 const deleteSelectionStateful = () => deleteSelectionImpl(canvasState)
 const canGroupSelectionStateful = computed<boolean>(() => canGroupSelectionImpl(canvasState))
 const canUngroupSelectionStateful = computed<boolean>(() => canUngroupSelectionImpl(canvasState))
+
+// Stateful wrappers for freehand helpers
+const clearFreehandSelection = () => clearFreehandSelectionImpl(canvasState)
+const createStrokeShape = (points: number[], id: string) => createStrokeShapeImpl(canvasState, points, id)
+const updateFreehandDraggableStates = () => updateFreehandDraggableStatesImpl(canvasState)
+const updateTimelineState = () => updateTimelineStateImpl(canvasState)
+const handleTimeUpdate = (time: number) => handleTimeUpdateImpl(canvasState, time)
+const downloadFreehandDrawing = () => downloadFreehandDrawingImpl(canvasState)
+const uploadFreehandDrawing = () => uploadFreehandDrawingImpl(canvasState)
+
+// Stateful wrappers for polygon helpers
+const clearPolygonSelection = () => clearPolygonSelectionImpl(canvasState)
+const updatePolygonControlPoints = () => updatePolygonControlPointsImpl(canvasState)
+const handlePolygonClick = (pos: { x: number, y: number }) => handlePolygonClickImpl(canvasState, pos)
+const handlePolygonMouseMove = () => handlePolygonMouseMoveImpl(canvasState)
+const handlePolygonEditMouseMove = () => handlePolygonEditMouseMoveImpl(canvasState)
+const finishPolygon = () => finishPolygonImpl(canvasState)
+const clearCurrentPolygon = () => clearCurrentPolygonImpl(canvasState)
+const setupPolygonModeWatcher = () => setupPolygonModeWatcherImpl(canvasState)
 
 // Set up callbacks for data updates
 canvasState.callbacks.freehandDataUpdate = () => updateBakedStrokeData(canvasState, appState)

--- a/src/sketches/handwriting_animator/canvas/ancillaryVisualizations.ts
+++ b/src/sketches/handwriting_animator/canvas/ancillaryVisualizations.ts
@@ -57,7 +57,7 @@ export const refreshAnciliaryVizWithState = (state: CanvasRuntimeState) => {
   if (!state.stage) return
   initAVLayerInState(state)
 
-  const roots = collectHierarchy().filter(h => h.depth === 0).map(h => h.node)
+  const roots = collectHierarchy(state).filter(h => h.depth === 0).map(h => h.node)
   const needed = new Map<string, {ctx: AVContext, def: AncillaryVisDefinition}>()
 
   roots.forEach(node => {
@@ -136,7 +136,8 @@ export const refreshAnciliaryViz = () => {
   if (!stage) return
   initAVLayer()
 
-  const roots = collectHierarchy().filter(h => h.depth === 0).map(h => h.node)
+  const state = getGlobalCanvasState()
+  const roots = collectHierarchy(state).filter(h => h.depth === 0).map(h => h.node)
   const needed = new Map<string, {ctx: AVContext, def: AncillaryVisDefinition}>()
 
   roots.forEach(node => {
@@ -189,7 +190,8 @@ export const setNodeMetadataWithAV = (
   node: Konva.Node,
   meta: Record<string, any> | undefined
 ) => {
-  origSetNodeMetadata(node, meta)
+  const state = getGlobalCanvasState()
+  origSetNodeMetadata(state, node, meta)
   refreshAnciliaryViz()
 }
 

--- a/src/sketches/handwriting_animator/canvas/selectTool.ts
+++ b/src/sketches/handwriting_animator/canvas/selectTool.ts
@@ -222,7 +222,7 @@ function completeSelectionRect(state: CanvasRuntimeState, isShiftHeld: boolean =
   // Clear existing selection if not holding shift
   if (!isShiftHeld) {
     selectionStore.clear(state)
-    updateTimelineState()
+    updateTimelineState(state)
   }
   
   // Add intersecting items to selection
@@ -426,7 +426,7 @@ export function duplicateSelection(state: CanvasRuntimeState) {
       topLevelNodes.forEach((node) => {
         // Freehand strokes and groups
         if (node instanceof Konva.Path || node instanceof Konva.Group) {
-          const dup = deepCloneWithNewIds(node, 50, 50)
+          const dup = deepCloneWithNewIds(state, node, 50, 50)
           const parent = node.getParent()
           if (parent) parent.add(dup)
           duplicates.push(dup)
@@ -442,7 +442,7 @@ export function duplicateSelection(state: CanvasRuntimeState) {
 
           // register data structures and handlers
           createPolygonItem(state, clone)
-          attachPolygonHandlers(clone)
+          attachPolygonHandlers(state, clone)
           polygonShapes().set(newId, {
             id: newId,
             points: [...clone.points()],

--- a/src/sketches/handwriting_animator/canvas/transformerManager.ts
+++ b/src/sketches/handwriting_animator/canvas/transformerManager.ts
@@ -109,8 +109,8 @@ function startTransformTrackingWithState(state: CanvasRuntimeState) {
   import('./freehandTool').then(({ getCurrentFreehandStateString }) => {
     import('./polygonTool').then(({ getCurrentPolygonStateString }) => {
       const startState = JSON.stringify({
-        freehand: getCurrentFreehandStateString(),
-        polygon: getCurrentPolygonStateString()
+        freehand: getCurrentFreehandStateString(state),
+        polygon: getCurrentPolygonStateString(state)
       })
       // Store in state rather than module global
       state.metadata.metadataText.value = startState // Temporarily using metadata field to store drag state
@@ -126,8 +126,8 @@ function finishTransformTrackingWithState(state: CanvasRuntimeState, operationNa
   import('./freehandTool').then(({ getCurrentFreehandStateString }) => {
     import('./polygonTool').then(({ getCurrentPolygonStateString }) => {
       const endState = JSON.stringify({
-        freehand: getCurrentFreehandStateString(),
-        polygon: getCurrentPolygonStateString()
+        freehand: getCurrentFreehandStateString(state),
+        polygon: getCurrentPolygonStateString(state)
       })
 
       if (dragStartState !== endState) {
@@ -144,9 +144,10 @@ function startTransformTracking() {
   // Import dynamically to avoid circular dependencies
   import('./freehandTool').then(({ getCurrentFreehandStateString }) => {
     import('./polygonTool').then(({ getCurrentPolygonStateString }) => {
+      const state = getGlobalCanvasState()
       dragStartState = JSON.stringify({
-        freehand: getCurrentFreehandStateString(),
-        polygon: getCurrentPolygonStateString()
+        freehand: getCurrentFreehandStateString(state),
+        polygon: getCurrentPolygonStateString(state)
       })
     })
   })
@@ -158,9 +159,10 @@ function finishTransformTracking(operationName: string) {
   // Import dynamically to avoid circular dependencies
   import('./freehandTool').then(({ getCurrentFreehandStateString }) => {
     import('./polygonTool').then(({ getCurrentPolygonStateString }) => {
+      const state = getGlobalCanvasState()
       const endState = JSON.stringify({
-        freehand: getCurrentFreehandStateString(),
-        polygon: getCurrentPolygonStateString()
+        freehand: getCurrentFreehandStateString(state),
+        polygon: getCurrentPolygonStateString(state)
       })
 
       if (dragStartState !== endState) {


### PR DESCRIPTION
## Summary
- update freehand tool helpers to accept a CanvasRuntimeState argument instead of reading the global singleton
- refactor polygon tool APIs and related modules to pass the runtime state through
- add state-aware wrappers in CanvasRoot and ancillary utilities so other features call the new signatures

## Testing
- npm run build *(fails: Vite cannot load src/rendering/stats imported from strokeLauncher.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0cca54b4832c873d13701326dbc5