### PR TITLE
Refactor canvas tools to pass canvas state explicitly

### DIFF
--- a/src/sketches/handwriting_animator/canvas/CanvasItem.ts
+++ b/src/sketches/handwriting_animator/canvas/CanvasItem.ts
@@ -1,7 +1,7 @@
 import Konva from "konva"
 import type { FreehandStroke } from "./freehandTool"
 import { uid } from "./canvasUtils"
-import { getGlobalCanvasState, type CanvasRuntimeState } from "./canvasState"
+import type { CanvasRuntimeState } from "./canvasState"
 
 export type ItemType = 'stroke' | 'strokeGroup' | 'polygon'
 
@@ -124,22 +124,22 @@ export const removeCanvasItemFromState = (state: CanvasRuntimeState, id: string)
 }
 
 // TEMPORARY FALLBACK WRAPPERS - REMOVE IN PHASE 7
-export const fromStroke = (shape: Konva.Path, strokeData?: FreehandStroke): CanvasItem => {
-  return createStrokeItem(getGlobalCanvasState(), shape, strokeData)
+export const fromStroke = (state: CanvasRuntimeState, shape: Konva.Path, strokeData?: FreehandStroke): CanvasItem => {
+  return createStrokeItem(state, shape, strokeData)
 }
 
-export const fromGroup = (group: Konva.Group): CanvasItem => {
-  return createGroupItem(getGlobalCanvasState(), group)
+export const fromGroup = (state: CanvasRuntimeState, group: Konva.Group): CanvasItem => {
+  return createGroupItem(state, group)
 }
 
-export const fromPolygon = (line: Konva.Line): CanvasItem => {
-  return createPolygonItem(getGlobalCanvasState(), line)
+export const fromPolygon = (state: CanvasRuntimeState, line: Konva.Line): CanvasItem => {
+  return createPolygonItem(state, line)
 }
 
-export const getCanvasItem = (node: Konva.Node): CanvasItem | undefined => {
-  return getCanvasItemFromState(getGlobalCanvasState(), node)
+export const getCanvasItem = (state: CanvasRuntimeState, node: Konva.Node): CanvasItem | undefined => {
+  return getCanvasItemFromState(state, node)
 }
 
-export const removeCanvasItem = (id: string) => {
-  removeCanvasItemFromState(getGlobalCanvasState(), id)
+export const removeCanvasItem = (state: CanvasRuntimeState, id: string) => {
+  removeCanvasItemFromState(state, id)
 }

--- a/src/sketches/handwriting_animator/canvas/MetadataEditor.vue
+++ b/src/sketches/handwriting_animator/canvas/MetadataEditor.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
-import type Konva from 'konva'
 
 interface Props {
-  activeNode: Konva.Node | null
+  metadata: Record<string, any> | null | undefined
   visible: boolean
+  canEdit: boolean
 }
 
 const props = defineProps<Props>()
@@ -21,17 +21,20 @@ const hasUnsavedChanges = computed(() => {
   return metadataText.value !== originalMetadataText.value
 })
 
-watch(() => props.activeNode, (node) => {
-  if (node) {
-    const metadata = node.getAttr('metadata') ?? {}
-    const jsonText = JSON.stringify(metadata, null, 2)
-    metadataText.value = jsonText
-    originalMetadataText.value = jsonText
-  } else {
-    metadataText.value = ''
-    originalMetadataText.value = ''
-  }
-}, { immediate: true })
+watch(
+  () => [props.metadata, props.canEdit],
+  ([metadata, canEdit]) => {
+    if (canEdit) {
+      const jsonText = JSON.stringify(metadata ?? {}, null, 2)
+      metadataText.value = jsonText
+      originalMetadataText.value = jsonText
+    } else {
+      metadataText.value = ''
+      originalMetadataText.value = ''
+    }
+  },
+  { immediate: true, deep: true }
+)
 
 const applyMetadata = () => {
   try {
@@ -57,7 +60,7 @@ const cancelEdit = () => {
       </div>
     </div>
     
-    <div v-if="activeNode">
+    <div v-if="canEdit">
       <p class="help">Edit the metadata as JSON:</p>
       <textarea 
         v-model="metadataText"

--- a/src/sketches/handwriting_animator/canvas/canvasState.ts
+++ b/src/sketches/handwriting_animator/canvas/canvasState.ts
@@ -212,9 +212,9 @@ export const getGlobalCanvasState = (): CanvasRuntimeState => {
 }
 
 // Convenience getters for cleaner access
-export const freehandStrokes = () => getGlobalCanvasState().freehand.strokes
-export const freehandStrokeGroups = () => getGlobalCanvasState().freehand.strokeGroups
-export const freehandLayers = () => getGlobalCanvasState().layers
-export const polygonShapes = () => getGlobalCanvasState().polygon.shapes
-export const polygonGroups = () => getGlobalCanvasState().polygon.groups
-export const canvasItems = () => getGlobalCanvasState().canvasItems
+export const freehandStrokes = (state: CanvasRuntimeState) => state.freehand.strokes
+export const freehandStrokeGroups = (state: CanvasRuntimeState) => state.freehand.strokeGroups
+export const freehandLayers = (state: CanvasRuntimeState) => state.layers
+export const polygonShapes = (state: CanvasRuntimeState) => state.polygon.shapes
+export const polygonGroups = (state: CanvasRuntimeState) => state.polygon.groups
+export const canvasItems = (state: CanvasRuntimeState) => state.canvasItems

--- a/src/sketches/handwriting_animator/canvas/commands.ts
+++ b/src/sketches/handwriting_animator/canvas/commands.ts
@@ -1,5 +1,4 @@
 import type { CanvasRuntimeState } from "./canvasState"
-import { getGlobalCanvasState as getCurrentCanvasState } from "./canvasState"
 
 // State-based command functions
 export const executeCommandWithState = (state: CanvasRuntimeState, name: string, action: () => void) => {
@@ -40,20 +39,20 @@ export const setGlobalPushCommand = (fn: (name: string, beforeState: string, aft
   globalPushCommand = fn
 }
 
-export const executeCommand = (name: string, action: () => void) => {
+export const executeCommand = (state: CanvasRuntimeState, name: string, action: () => void) => {
   if (globalExecuteCommand) {
     globalExecuteCommand(name, action)
   } else {
     // Fall back to state-based approach
-    executeCommandWithState(getCurrentCanvasState(), name, action)
+    executeCommandWithState(state, name, action)
   }
 }
 
-export const pushCommandWithStates = (name: string, beforeState: string, afterState: string) => {
+export const pushCommandWithStates = (state: CanvasRuntimeState, name: string, beforeState: string, afterState: string) => {
   if (globalPushCommand) {
     globalPushCommand(name, beforeState, afterState)
   } else {
     // Fall back to state-based approach
-    pushCommandWithStatesAndState(getCurrentCanvasState(), name, beforeState, afterState)
+    pushCommandWithStatesAndState(state, name, beforeState, afterState)
   }
 }


### PR DESCRIPTION
## Summary
- update canvas helper functions to require an explicit CanvasRuntimeState instead of relying on the global getter
- thread the runtime state through select, freehand, polygon, and ancillary visualization modules to remove getGlobalCanvasState usages
- adjust CanvasRoot wiring so tool setup, event handlers, and metadata editor reuse the shared state instance when calling helpers

## Testing
- `npm run type-check` *(fails: existing project-wide type errors surfaced outside the touched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1c2bf0a0832c999afcf349ad0b61