### PR TITLE
Refactor handwriting animator timeline to use local loop

### DIFF
--- a/src/sketches/handwriting_animator/canvas/animationLoop.ts
+++ b/src/sketches/handwriting_animator/canvas/animationLoop.ts
@@ -1,0 +1,50 @@
+export interface CancelToken {
+  canceled: boolean
+}
+
+export interface AnimationLoopHandle {
+  cancel: () => void
+  token: CancelToken
+}
+
+export type AnimationFrameCallback = (timestamp: number, token: CancelToken) => boolean | void
+
+const createCancelToken = (): CancelToken => ({
+  canceled: false
+})
+
+const stopLoop = (handle: { frameId: number | null; token: CancelToken }) => {
+  if (handle.token.canceled) return
+  handle.token.canceled = true
+  if (handle.frameId !== null) {
+    cancelAnimationFrame(handle.frameId)
+    handle.frameId = null
+  }
+}
+
+export const startAnimationLoop = (callback: AnimationFrameCallback): AnimationLoopHandle => {
+  const state = {
+    frameId: null as number | null,
+    token: createCancelToken()
+  }
+
+  const step = (timestamp: number) => {
+    if (state.token.canceled) return
+
+    state.frameId = null
+    const shouldContinue = callback(timestamp, state.token)
+    if (state.token.canceled || shouldContinue === false) {
+      stopLoop(state)
+      return
+    }
+
+    state.frameId = requestAnimationFrame(step)
+  }
+
+  state.frameId = requestAnimationFrame(step)
+
+  return {
+    token: state.token,
+    cancel: () => stopLoop(state)
+  }
+}

--- a/src/sketches/handwriting_animator/canvas/polygonTool.ts
+++ b/src/sketches/handwriting_animator/canvas/polygonTool.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable prefer-const */
-import { TimeContext, CancelablePromiseProxy, launch } from "@/channels/base_time_context"
 import { findClosestPolygonLineAtPoint } from "@/creativeAlgs/shapeHelpers"
 import Konva from "konva"
 import { type ShallowReactive, shallowReactive, ref, watch } from "vue"


### PR DESCRIPTION
## Summary
- replace the handwriting animator timeline's channel-based play/pause loop with a local requestAnimationFrame helper
- add a reusable canvas animationLoop utility and remove the unused channel-related prop/import

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc09a7ef60832caee92cce716e9345