### PR TITLE
Move polygon tool helper into local module

### DIFF
--- a/src/sketches/handwriting_animator/canvas/polygonGeometry.ts
+++ b/src/sketches/handwriting_animator/canvas/polygonGeometry.ts
@@ -1,0 +1,46 @@
+export type Point = { x: number; y: number }
+
+export type Polygon = {
+  points: Point[]
+}
+
+const lineToPointDistance = (p1: Point, p2: Point, point: Point): number => {
+  const vx = p2.x - p1.x
+  const vy = p2.y - p1.y
+  const wx = point.x - p1.x
+  const wy = point.y - p1.y
+
+  const c1 = vx * wx + vy * wy
+  if (c1 <= 0) return Math.hypot(wx, wy) // point is before p1
+
+  const c2 = vx * vx + vy * vy
+  if (c2 <= c1) return Math.hypot(point.x - p2.x, point.y - p2.y) // point is after p2
+
+  const b = c1 / c2 // projection falls on segment
+  const pbx = p1.x + b * vx
+  const pby = p1.y + b * vy
+  return Math.hypot(point.x - pbx, point.y - pby)
+}
+
+export function findClosestPolygonLineAtPoint(
+  polygons: Polygon[],
+  point: Point
+): { polygonIndex: number; lineIndex: number; distance: number } {
+  let closestPolygonIndex = -1
+  let closestLineIndex = -1
+  let closestDistance = Infinity
+  for (let i = 0; i < polygons.length; i++) {
+    const polygon = polygons[i]
+    for (let j = 0; j < polygon.points.length; j++) {
+      const p1 = polygon.points[j]
+      const p2 = polygon.points[(j + 1) % polygon.points.length]
+      const distance = lineToPointDistance(p1, p2, point)
+      if (distance < closestDistance) {
+        closestDistance = distance
+        closestPolygonIndex = i
+        closestLineIndex = j
+      }
+    }
+  }
+  return { polygonIndex: closestPolygonIndex, lineIndex: closestLineIndex, distance: closestDistance }
+}

--- a/src/sketches/handwriting_animator/canvas/polygonTool.ts
+++ b/src/sketches/handwriting_animator/canvas/polygonTool.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable prefer-const */
-import { findClosestPolygonLineAtPoint } from "@/creativeAlgs/shapeHelpers"
 import Konva from "konva"
 import { type ShallowReactive, shallowReactive, ref, watch } from "vue"
+import { findClosestPolygonLineAtPoint } from "./polygonGeometry"
 import type { PolygonRenderData, FlattenedPolygon } from "./canvasState"
 import { executeCommand, pushCommandWithStates } from "./commands"
 import { getCurrentFreehandStateString } from './freehandTool'


### PR DESCRIPTION
## Summary
- remove the unused base_time_context dependency from the polygon tool
- add a local polygonGeometry helper that provides findClosestPolygonLineAtPoint
- update the polygon tool to consume the new helper implementation

## Testing
- npm run type-check *(fails: pre-existing type errors throughout unrelated sketches)*

------
https://chatgpt.com/codex/tasks/task_e_68cc09cd4fa0832c9b3e302637e6b1f0