### PR TITLE
Add canvas keyboard helper

### DIFF
--- a/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
+++ b/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
@@ -4,7 +4,7 @@ import { createCanvasRuntimeState, setGlobalCanvasState, type CanvasRuntimeState
 import * as selectionStore from './selectionStore';
 import { getCanvasItem } from './CanvasItem';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
-import { clearListeners, singleKeydownEvent } from '@/io/keyboardAndMouse';
+import { clearListeners, singleKeydownEvent } from './keyboard';
 import Konva from 'konva';
 import Timeline from './Timeline.vue';
 import HierarchicalMetadataEditor from './HierarchicalMetadataEditor.vue';

--- a/src/sketches/handwriting_animator/canvas/keyboard.ts
+++ b/src/sketches/handwriting_animator/canvas/keyboard.ts
@@ -1,0 +1,17 @@
+const eventListeners: Array<{ type: 'keydown'; cb: (ev: KeyboardEvent) => void; target: HTMLElement }> = []
+
+export function clearListeners() {
+  eventListeners.forEach((ev) => ev.target.removeEventListener(ev.type, ev.cb))
+  eventListeners.length = 0
+}
+
+export function singleKeydownEvent(key: string, listener: (ev: KeyboardEvent) => void, target: HTMLElement = document.body) {
+  const cb = (ev: KeyboardEvent) => {
+    if (ev.key === key) {
+      listener(ev)
+    }
+  }
+
+  eventListeners.push({ type: 'keydown', cb, target })
+  target.addEventListener('keydown', cb)
+}


### PR DESCRIPTION
## Summary
- add a canvas-scoped keyboard helper that provides `singleKeydownEvent` and `clearListeners`
- update `CanvasRoot.vue` to consume the local helper instead of the alias-based import

## Testing
- npm run type-check *(fails: existing TypeScript errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0a777000832cb4d92d77fd8abe13