### PR TITLE
Refactor canvas commands to rely on runtime state

### DIFF
--- a/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
+++ b/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
@@ -13,7 +13,6 @@ import { clearFreehandSelection as clearFreehandSelectionImpl, createStrokeShape
 import { freehandStrokes } from './canvasState';
 import { getPointsBounds } from './canvasUtils';
 import { CommandStack } from './commandStack';
-import { setGlobalExecuteCommand, setGlobalPushCommand } from './commands';
 import { ensureHighlightLayer, metadataToolkit } from './metadata';
 import { clearPolygonSelection as clearPolygonSelectionImpl, updatePolygonControlPoints as updatePolygonControlPointsImpl, deserializePolygonState, handlePolygonClick as handlePolygonClickImpl, handlePolygonMouseMove as handlePolygonMouseMoveImpl, handlePolygonEditMouseMove as handlePolygonEditMouseMoveImpl, finishPolygon as finishPolygonImpl, clearCurrentPolygon as clearCurrentPolygonImpl, serializePolygonState, getCurrentPolygonStateString, restorePolygonState, updateBakedPolygonData, initPolygonLayers, setupPolygonModeWatcher as setupPolygonModeWatcherImpl } from './polygonTool';
 import { initAVLayer, refreshAnciliaryViz } from './ancillaryVisualizations';
@@ -349,10 +348,6 @@ onMounted(async () => {
 
     // Initialize ancillary visualizations layer
     initAVLayer(canvasState)
-
-    // Set up executeCommand callbacks for tools
-    setGlobalExecuteCommand(executeCommand)
-    setGlobalPushCommand((name, beforeState, afterState) => commandStack.pushCommand(name, beforeState, afterState))
 
 
     // Selection rectangle is created by core/selectTool.initializeSelectTool

--- a/src/sketches/handwriting_animator/canvas/commands.ts
+++ b/src/sketches/handwriting_animator/canvas/commands.ts
@@ -1,7 +1,7 @@
 import type { CanvasRuntimeState } from "./canvasState"
 
-// State-based command functions
-export const executeCommandWithState = (state: CanvasRuntimeState, name: string, action: () => void) => {
+// Command helpers rely exclusively on the callbacks stored in CanvasRuntimeState
+export const executeCommand = (state: CanvasRuntimeState, name: string, action: () => void) => {
   if (!state.command.executeCommand) {
     console.warn('executeCommand called before setup - falling back to direct execution')
     action()
@@ -10,7 +10,12 @@ export const executeCommandWithState = (state: CanvasRuntimeState, name: string,
   state.command.executeCommand(name, action)
 }
 
-export const pushCommandWithStatesAndState = (state: CanvasRuntimeState, name: string, beforeState: string, afterState: string) => {
+export const pushCommandWithStates = (
+  state: CanvasRuntimeState,
+  name: string,
+  beforeState: string,
+  afterState: string
+) => {
   if (!state.command.pushCommand) {
     console.warn('pushCommandWithStates called before setup - ignoring')
     return
@@ -23,36 +28,9 @@ export const setCommandExecutor = (state: CanvasRuntimeState, fn: (name: string,
   state.command.executeCommand = fn
 }
 
-export const setCommandPusher = (state: CanvasRuntimeState, fn: (name: string, beforeState: string, afterState: string) => void) => {
+export const setCommandPusher = (
+  state: CanvasRuntimeState,
+  fn: (name: string, beforeState: string, afterState: string) => void
+) => {
   state.command.pushCommand = fn
-}
-
-// TEMPORARY FALLBACK WRAPPERS - REMOVE IN PHASE 7
-let globalExecuteCommand: ((name: string, action: () => void) => void) | undefined
-let globalPushCommand: ((name: string, beforeState: string, afterState: string) => void) | undefined
-
-export const setGlobalExecuteCommand = (fn: (name: string, action: () => void) => void) => {
-  globalExecuteCommand = fn
-}
-
-export const setGlobalPushCommand = (fn: (name: string, beforeState: string, afterState: string) => void) => {
-  globalPushCommand = fn
-}
-
-export const executeCommand = (state: CanvasRuntimeState, name: string, action: () => void) => {
-  if (globalExecuteCommand) {
-    globalExecuteCommand(name, action)
-  } else {
-    // Fall back to state-based approach
-    executeCommandWithState(state, name, action)
-  }
-}
-
-export const pushCommandWithStates = (state: CanvasRuntimeState, name: string, beforeState: string, afterState: string) => {
-  if (globalPushCommand) {
-    globalPushCommand(name, beforeState, afterState)
-  } else {
-    // Fall back to state-based approach
-    pushCommandWithStatesAndState(state, name, beforeState, afterState)
-  }
 }

--- a/src/sketches/handwriting_animator/canvas/selectionStore.ts
+++ b/src/sketches/handwriting_animator/canvas/selectionStore.ts
@@ -1,6 +1,6 @@
 
 import type { CanvasItem, ItemType } from './CanvasItem'
-import { executeCommandWithState } from './commands'
+import { executeCommand } from './commands'
 import type { CanvasRuntimeState } from './canvasState'
 import Konva from 'konva'
 
@@ -166,7 +166,7 @@ function setMetadataForState(
   item: CanvasItem,
   meta: Record<string, any> | undefined
 ) {
-  executeCommandWithState(state, 'Edit Metadata', () => {
+  executeCommand(state, 'Edit Metadata', () => {
     item.setMetadata(meta)
     updateGPUAndVisualization(state)
   })
@@ -176,7 +176,7 @@ function setMetadataForState(
 function setMetadataForSelectedInState(state: CanvasRuntimeState, meta: Record<string, any> | undefined) {
   if (state.selection.items.size === 0) return
   
-  executeCommandWithState(state, 'Edit Multiple Metadata', () => {
+  executeCommand(state, 'Edit Multiple Metadata', () => {
     for (const item of state.selection.items) {
       item.setMetadata(meta)
     }

--- a/src/sketches/handwriting_animator/notes.md
+++ b/src/sketches/handwriting_animator/notes.md
@@ -7,30 +7,17 @@
 - [ ] select highlighting still not robust
 - [X] slider replay not robust when nothing selected
 - [ ] slider replay not robust for groups,nested groups
+- [ ] grid mode doesn't work
 
 
 
 
 
-
-
-remove appState dependency for selectTool.ts
 
 remove tool-specific selection functions in freehandTool.ts and polygonTool.ts
 update/remove tool specific metadata setting calls
 
-
-the following functions take the vue-level appState as an argument, and at some point, set data on the appState
-- serializePolygonState
-- deserializePolygonState
-- updateBakedPolygonData
-- serializeFreehandState
-- deserializeFreehandState
-- updateBakedFreehandData
-
-instead of directly setting it on the appState, there should be a callback defined on the canvasState object that updates the vue level appState, and these functions should call that callback instead of setting the data directly on the appState. for simplicity, there should just be one monolithic callback that takes the canvasState and updates the appState accordingly, and it can be called across all tools 
-
-Similarly, there is a callback function freehandDataUpdateCallback defined on the vue level appState, which should be moved to live on the canvasState, as different canvas instances might want different behavior. it could also just be removed as a separate entity and it's logic moved into the state setting callback
+tool level cursor stuff unused? remove or fix
 
 
 


### PR DESCRIPTION
## Summary
- remove the temporary global command fallbacks so helpers call the CanvasRuntimeState command callbacks directly
- update command consumers, including the selection store and CanvasRoot, to rely on the runtime state wiring instead of module globals

## Testing
- npm run type-check *(fails: existing type errors across unrelated sketches)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0a873104832c8be2beb2e4ad88dd