### PR TITLE
Scope metadata highlight state per canvas

### DIFF
--- a/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
+++ b/src/sketches/handwriting_animator/canvas/CanvasRoot.vue
@@ -13,7 +13,7 @@ import { clearFreehandSelection as clearFreehandSelectionImpl, createStrokeShape
 import { freehandStrokes } from './canvasState';
 import { getPointsBounds } from './canvasUtils';
 import { CommandStack } from './commandStack';
-import { ensureHighlightLayer, metadataToolkit } from './metadata';
+import { ensureHighlightLayer, createMetadataToolkit } from './metadata';
 import { clearPolygonSelection as clearPolygonSelectionImpl, updatePolygonControlPoints as updatePolygonControlPointsImpl, deserializePolygonState, handlePolygonClick as handlePolygonClickImpl, handlePolygonMouseMove as handlePolygonMouseMoveImpl, handlePolygonEditMouseMove as handlePolygonEditMouseMoveImpl, finishPolygon as finishPolygonImpl, clearCurrentPolygon as clearCurrentPolygonImpl, serializePolygonState, getCurrentPolygonStateString, restorePolygonState, updateBakedPolygonData, initPolygonLayers, setupPolygonModeWatcher as setupPolygonModeWatcherImpl } from './polygonTool';
 import { initAVLayer, refreshAnciliaryViz } from './ancillaryVisualizations';
 import { initializeTransformer } from './transformerManager';
@@ -45,6 +45,7 @@ const resolution = computed(() => props.resolution)
 // Create and initialize canvas runtime state
 const canvasState: CanvasRuntimeState = createCanvasRuntimeState()
 setGlobalCanvasState(canvasState)
+const metadataToolkit = createMetadataToolkit(canvasState)
 
 const activeTool = canvasState.activeTool
 const metadataEditorVisible = canvasState.metadata.showEditor
@@ -209,7 +210,7 @@ const applyToolMode = (state: CanvasRuntimeState, tool: 'select' | 'freehand' | 
 
     // Ensure transformer/selection overlay sits above shapes
     selectionLayer?.moveToTop()
-    if (stageRef) ensureHighlightLayer(stageRef).moveToTop()
+    if (stageRef) ensureHighlightLayer(canvasState, stageRef).moveToTop()
   } else if (tool === 'freehand') {
     // Freehand drawing mode
     freehandShapeLayer?.listening(true)
@@ -338,7 +339,7 @@ onMounted(async () => {
     initializeSelectToolStateful(selectionLayerForTool)
 
     // Add metadata highlight layer on top
-    const metadataHighlightLayer = ensureHighlightLayer(stageInstance)
+    const metadataHighlightLayer = ensureHighlightLayer(canvasState, stageInstance)
     // Keep transformer layer above all interactive shape layers to prevent pointer blocking
     canvasState.layers.transformerLayer?.moveToTop()
     // Keep highlight visuals on top (non-listening, so it won't block interaction)

--- a/src/sketches/handwriting_animator/canvas/canvasState.ts
+++ b/src/sketches/handwriting_animator/canvas/canvasState.ts
@@ -151,6 +151,11 @@ export interface CanvasRuntimeState {
     activeNode: Ref<Konva.Node | null>
     metadataText: Ref<string>
     showEditor: Ref<boolean>
+    highlight: {
+      layer?: Konva.Layer
+      metadataRect?: Konva.Rect
+      hoverRect?: Konva.Rect
+    }
   }
   ancillary: {
     activeVisualizations: Ref<Set<string>>
@@ -238,7 +243,8 @@ export const createCanvasRuntimeState = (): CanvasRuntimeState => {
     metadata: {
       activeNode: ref(null),
       metadataText: ref(''),
-      showEditor: ref(false)
+      showEditor: ref(false),
+      highlight: {}
     },
     ancillary: {
       activeVisualizations: ref(new Set<string>()),

--- a/src/sketches/handwriting_animator/canvas/metadata/defaultToolkit.ts
+++ b/src/sketches/handwriting_animator/canvas/metadata/defaultToolkit.ts
@@ -1,4 +1,5 @@
 import type Konva from 'konva'
+import type { CanvasRuntimeState } from '../canvasState'
 import { collectHierarchyFromRoot, type HierarchyEntry } from './hierarchy'
 import { updateMetadataHighlight, updateHoverHighlight } from './highlight'
 
@@ -15,8 +16,8 @@ export interface MetadataToolkit {
   updateHoverHighlight(node?: Konva.Node): void
 }
 
-// Default implementation that works for every tool
-export const defaultMetadataToolkit: MetadataToolkit = {
+// Factory to create a toolkit instance bound to a specific canvas runtime state
+export const createMetadataToolkit = (state: CanvasRuntimeState): MetadataToolkit => ({
   setNodeMetadata: (node: Konva.Node, meta: any) => {
     // Set the metadata on the node
     if (meta === undefined || Object.keys(meta).length === 0) {
@@ -28,9 +29,6 @@ export const defaultMetadataToolkit: MetadataToolkit = {
   },
 
   collectHierarchyFromRoot,
-  updateMetadataHighlight,
-  updateHoverHighlight
-}
-
-// Export for direct use
-export const metadataToolkit = defaultMetadataToolkit
+  updateMetadataHighlight: (node?: Konva.Node) => updateMetadataHighlight(state, node),
+  updateHoverHighlight: (node?: Konva.Node) => updateHoverHighlight(state, node)
+})

--- a/src/sketches/handwriting_animator/canvas/metadata/highlight.ts
+++ b/src/sketches/handwriting_animator/canvas/metadata/highlight.ts
@@ -1,42 +1,50 @@
 import Konva from 'konva'
+import type { CanvasRuntimeState } from '../canvasState'
 
-// Global highlight state - shared across all tools
-let metadataHighlightLayer: Konva.Layer | undefined = undefined
-let metadataHighlightRect: Konva.Rect | undefined = undefined
-let hoverHighlightRect: Konva.Rect | undefined = undefined
+const getHighlightLayer = (state: CanvasRuntimeState) => state.metadata.highlight.layer
+const getMetadataRect = (state: CanvasRuntimeState) => state.metadata.highlight.metadataRect
+const getHoverRect = (state: CanvasRuntimeState) => state.metadata.highlight.hoverRect
 
 // Ensure highlight layer exists and is properly set up
-export const ensureHighlightLayer = (stage: Konva.Stage): Konva.Layer => {
-  if (metadataHighlightLayer) return metadataHighlightLayer
+export const ensureHighlightLayer = (state: CanvasRuntimeState, stage: Konva.Stage): Konva.Layer => {
+  const existingLayer = getHighlightLayer(state)
+  if (existingLayer) return existingLayer
 
-  metadataHighlightLayer = new Konva.Layer({ listening: false })
-  
+  const metadataHighlightLayer = new Konva.Layer({ listening: false })
+
   // Red dotted border for active selection
-  metadataHighlightRect = new Konva.Rect({
+  const metadataHighlightRect = new Konva.Rect({
     stroke: 'red',
     strokeWidth: 2,
     dash: [4, 4],
     listening: false,
     visible: false
   })
-  
+
   // Green dotted border for hover
-  hoverHighlightRect = new Konva.Rect({
+  const hoverHighlightRect = new Konva.Rect({
     stroke: 'green',
     strokeWidth: 2,
     dash: [4, 4],
     listening: false,
     visible: false
   })
-  
+
   metadataHighlightLayer.add(metadataHighlightRect)
   metadataHighlightLayer.add(hoverHighlightRect)
   stage.add(metadataHighlightLayer)
-  
+
+  state.metadata.highlight.layer = metadataHighlightLayer
+  state.metadata.highlight.metadataRect = metadataHighlightRect
+  state.metadata.highlight.hoverRect = hoverHighlightRect
+  state.layers.metadataHighlight = metadataHighlightLayer
+
   return metadataHighlightLayer
 }
 
-export const updateMetadataHighlight = (node?: Konva.Node) => {
+export const updateMetadataHighlight = (state: CanvasRuntimeState, node?: Konva.Node) => {
+  const metadataHighlightRect = getMetadataRect(state)
+  const metadataHighlightLayer = getHighlightLayer(state)
   if (!metadataHighlightRect || !metadataHighlightLayer) return
 
   if (!node) {
@@ -56,7 +64,9 @@ export const updateMetadataHighlight = (node?: Konva.Node) => {
   metadataHighlightLayer.batchDraw()
 }
 
-export const updateHoverHighlight = (node?: Konva.Node) => {
+export const updateHoverHighlight = (state: CanvasRuntimeState, node?: Konva.Node) => {
+  const hoverHighlightRect = getHoverRect(state)
+  const metadataHighlightLayer = getHighlightLayer(state)
   if (!hoverHighlightRect || !metadataHighlightLayer) return
 
   if (!node) {
@@ -77,11 +87,11 @@ export const updateHoverHighlight = (node?: Konva.Node) => {
 }
 
 // For backward compatibility with existing freehandTool code
-export const createMetadataHighlight = (stage: Konva.Stage): Konva.Layer => {
-  return ensureHighlightLayer(stage)
+export const createMetadataHighlight = (state: CanvasRuntimeState, stage: Konva.Stage): Konva.Layer => {
+  return ensureHighlightLayer(state, stage)
 }
 
 // Export the layer refs for tools that need direct access (for backward compatibility)
-export const getMetadataHighlightLayer = () => metadataHighlightLayer
-export const getMetadataHighlightRect = () => metadataHighlightRect
-export const getHoverHighlightRect = () => hoverHighlightRect
+export const getMetadataHighlightLayer = (state: CanvasRuntimeState) => getHighlightLayer(state)
+export const getMetadataHighlightRect = (state: CanvasRuntimeState) => getMetadataRect(state)
+export const getHoverHighlightRect = (state: CanvasRuntimeState) => getHoverRect(state)

--- a/src/sketches/handwriting_animator/canvas/metadata/index.ts
+++ b/src/sketches/handwriting_animator/canvas/metadata/index.ts
@@ -1,7 +1,4 @@
 // Barrel exports for metadata module
 export * from './hierarchy'
 export * from './highlight'
-export * from './defaultToolkit'
-
-// Re-export the main toolkit for convenient import
-export { defaultMetadataToolkit as metadataToolkit } from './defaultToolkit'
+export { createMetadataToolkit, type MetadataToolkit } from './defaultToolkit'


### PR DESCRIPTION
## Summary
- store metadata highlight layer and rect references on the canvas runtime state
- make highlight utilities read/write per-state values so each canvas instance owns its highlight primitives
- update CanvasRoot and the metadata toolkit to pass runtime state when creating highlights

## Testing
- npm run type-check *(fails: existing TypeScript errors in unrelated sketches)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0a821200832cae416f2f237a6421